### PR TITLE
💡 Lumen: Accesibilidad y Semántica en el Podcast

### DIFF
--- a/.axioma/lumen.md
+++ b/.axioma/lumen.md
@@ -6,3 +6,5 @@
 ## 2026-05-09 - Blog Title Standardization | Learning: Blog post titles should be concise and focused to maintain clarity and UI consistency. | Acción: Added a rule that blog post titles must not contain subtitles or extra descriptive phrases beyond the main topic.
 
 ## 2025-05-14 - Dynamic Sidebar Content Promotion | Learning: Using getCollection allows for automated content promotion (e.g., Personal Blog entries) while maintaining styling consistency via shared CSS classes like .skill and .upper. | Acción: Created PersonalBlog.astro to automatically fetch and list the latest 5 blog posts, replacing hardcoded links in the sidebar.
+
+## 2026-05-11 - Interactive Accessibility Standards | Learning: Using non-semantic elements (like `<span>`) for interactive components prevents keyboard navigation and fails screen readers. | Acción: Established the use of semantic `<button>` with dynamic `aria-label` and visible `:focus-visible` states for all floating interactive components.

--- a/src/components/Podcast.astro
+++ b/src/components/Podcast.astro
@@ -3,7 +3,7 @@ import IconPause from './Icons/IconPause.astro'
 import IconPodcast from './Icons/IconPodcast.astro'
 ---
 
-<span class="container no-print" title="Hear about me">
+<button class="container no-print" aria-label="Play podcast summary" title="Hear about me">
   <IconPodcast class="play-icon" />
   <IconPause class="pause-icon" />
   <audio controls style="display: none" id="podcast-audio">
@@ -12,15 +12,17 @@ import IconPodcast from './Icons/IconPodcast.astro'
 
   <script>
     document.addEventListener('DOMContentLoaded', () => {
-      const container = document.querySelector('.container') as HTMLDivElement
+      const container = document.querySelector('.container') as HTMLButtonElement
       const audio = document.getElementById('podcast-audio') as HTMLAudioElement
       if (container && audio) {
         container.addEventListener('click', () => {
           if (audio.paused) {
             container.classList.add('playing')
+            container.setAttribute('aria-label', 'Pause podcast summary')
             audio.play()
           } else {
             container.classList.remove('playing')
+            container.setAttribute('aria-label', 'Play podcast summary')
             audio.pause()
           }
         })
@@ -43,9 +45,16 @@ import IconPodcast from './Icons/IconPodcast.astro'
       cursor: pointer;
       opacity: 1;
       transition: all 0.3s;
+      border: none;
+      padding: 0;
 
       &:hover {
         opacity: 0.8;
+      }
+
+      &:focus-visible {
+        outline: 2px solid light-dark(#000, #fff);
+        outline-offset: 4px;
       }
 
       &.playing {
@@ -73,4 +82,4 @@ import IconPodcast from './Icons/IconPodcast.astro'
       }
     }
   </style>
-</span>
+</button>


### PR DESCRIPTION
# Qué:
- Refactorización de `Podcast.astro` para utilizar un elemento `<button>` semántico en lugar de un `<span>`.
- Implementación de etiquetas `aria-label` dinámicas que reflejan el estado de reproducción ("Play podcast summary" / "Pause podcast summary").
- Adición de estados `:focus-visible` para una navegación por teclado clara y accesible.

# Por qué:
- Los componentes interactivos deben ser semánticos y accesibles por teclado para cumplir con los estándares de Lumen y mejorar la experiencia de usuario (UX).

# Evidencia Visual:
- Se verificó el estado de foco en modo claro y oscuro.
- Se confirmó que el `aria-label` cambia correctamente tras la interacción.
- Se validó que el CV sigue ajustándose a una sola página A4 en la vista de impresión.

# Checklist:
- [x] Verificado en Modo Claro y Oscuro.
- [x] Verificado en Móvil, Tablet y Desktop.
- [x] Prueba de Impresión CV 1 hoja A4 intacta.
- [x] Cambios < 30 líneas (Aproximadamente 20 líneas modificadas).

---
*PR created automatically by Jules for task [18261998974695995647](https://jules.google.com/task/18261998974695995647) started by @galiprandi*