### PR TITLE
Limit personal blog entries in aside and add 'More articles' link

### DIFF
--- a/src/components/Aside/PersonalBlog.astro
+++ b/src/components/Aside/PersonalBlog.astro
@@ -8,7 +8,7 @@ const posts = allPosts
     (a: CollectionEntry<"blog">, b: CollectionEntry<"blog">) =>
       b.data.pubDate.valueOf() - a.data.pubDate.valueOf(),
   )
-  .slice(0, 5);
+  .slice(0, 4);
 
 const base = "/me";
 ---
@@ -25,5 +25,8 @@ const base = "/me";
         </li>
       ))
     }
+    <li>
+      <a href={`${base}/blog`}><strong>More articles...</strong></a>
+    </li>
   </ul>
 </section>


### PR DESCRIPTION
Reduced the number of displayed recent blog posts from 5 to 4 in the sidebar's Personal Blog section. Added a "More articles..." link that redirects to the blog's home page (/me/blog). Verified with Playwright and successful build.

---
*PR created automatically by Jules for task [16065524062744496763](https://jules.google.com/task/16065524062744496763) started by @galiprandi*