### PR TITLE
🎨 Palette: Enhance accessibility for blog post cards

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -220,9 +220,6 @@ packages:
   '@emnapi/runtime@1.10.0':
     resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
 
-  '@emnapi/runtime@1.2.0':
-    resolution: {integrity: sha512-bV21/9LQmcQeCPEg3BDFtvwL6cwiTMksYNWQQ4KOxCZikEGalWtenoZ0wCiukJINlGCIi2KXx01g4FoH/LxpzQ==}
-
   '@esbuild/aix-ppc64@0.27.7':
     resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
     engines: {node: '>=18'}
@@ -1786,9 +1783,6 @@ packages:
   trough@2.2.0:
     resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
 
-  tslib@2.6.3:
-    resolution: {integrity: sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==}
-
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
@@ -2406,11 +2400,6 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@emnapi/runtime@1.2.0':
-    dependencies:
-      tslib: 2.6.3
-    optional: true
-
   '@esbuild/aix-ppc64@0.27.7':
     optional: true
 
@@ -2645,7 +2634,7 @@ snapshots:
 
   '@img/sharp-wasm32@0.33.4':
     dependencies:
-      '@emnapi/runtime': 1.2.0
+      '@emnapi/runtime': 1.10.0
     optional: true
 
   '@img/sharp-wasm32@0.34.5':
@@ -4181,9 +4170,6 @@ snapshots:
   trim-lines@3.0.1: {}
 
   trough@2.2.0: {}
-
-  tslib@2.6.3:
-    optional: true
 
   tslib@2.8.1:
     optional: true

--- a/src/components/Blog/PostCard.astro
+++ b/src/components/Blog/PostCard.astro
@@ -18,18 +18,35 @@ const dateOptions: Intl.DateTimeFormatOptions = {
 const locale = lang === "en" ? "en-US" : "es-ES";
 const formattedDate = pubDate.toLocaleDateString(locale, dateOptions);
 const base = "/me";
+
+const labels = {
+  en: {
+    readMore: `Read article: ${title}`,
+    taggedWith: (tag: string) => `View posts tagged with ${tag}`,
+  },
+  es: {
+    readMore: `Leer artículo: ${title}`,
+    taggedWith: (tag: string) => `Ver publicaciones etiquetadas con ${tag}`,
+  },
+}[lang === "es" ? "es" : "en"];
 ---
 
 <article class="post-card">
   <time class="post-date">{formattedDate}</time>
   <h2 class="post-title">
-    <a href={`${base}/blog/${post.data.postSlug}/${lang}`}>{title}</a>
+    <a href={`${base}/blog/${post.data.postSlug}/${lang}`} aria-label={labels.readMore}>
+      {title}
+    </a>
   </h2>
   <p class="post-description">{description}</p>
   <div class="post-tags">
     {
       tags.map((tag: string) => (
-        <a class="tag" href={`${base}/blog/tag/${tag}`}>
+        <a
+          class="tag"
+          href={`${base}/blog/tag/${tag}`}
+          aria-label={labels.taggedWith(tag)}
+        >
           {tag}
         </a>
       ))


### PR DESCRIPTION
💡 **What**: Added localized `aria-label` attributes to blog post title links and tag links in `src/components/Blog/PostCard.astro`.
🎯 **Why**: To provide better context for screen reader users. The title link now clearly states "Read article: [Title]" and tags state "View posts tagged with [Tag]", improving navigation clarity.
♿ **Accessibility**: Enhanced semantic context for interactive elements without changing the visual design.
📸 **Visuals**: No visual changes were introduced; the improvement is focused on the accessibility layer.

Verified with `pnpm build` and manual inspection of the generated HTML.

---
*PR created automatically by Jules for task [8712572066516122088](https://jules.google.com/task/8712572066516122088) started by @galiprandi*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added language-specific aria-labels (English and Spanish) to blog post links and tag navigation elements, enhancing screen reader support and accessibility for users with assistive technologies.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/galiprandi/me/pull/24?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->