### PR TITLE
🐜 Adrián: Implementación de Pestaña de Reputación en Ranking

### DIFF
--- a/padelapp/specs/ranking.md
+++ b/padelapp/specs/ranking.md
@@ -1,0 +1,101 @@
+# Especificación de Ranking (MVP)
+
+- Path: `/ranking`
+- Estado: Partially Implemented (Vista global implementada; Pestaña de Reputación agregada con datos mock)
+- Público: solo usuarios autenticados (mismo guard que layout `(app)`)
+
+## Objetivo
+- Mostrar la tabla de posiciones de jugadores de pádel considerando desempeño reciente y confiabilidad (asistencia).
+- Permitir al usuario ver su posición actual, puntos y variación.
+- Prioridad mobile-first, CTA y affordances claros.
+
+## Alcance (MVP)
+- Ranking **individual** por jugador (no contempla parejas todavía).
+- Tabla global de ranking (sin filtros por club/zona aún).
+- Cada fila: posición, nombre preferido (alias > displayName), nivel, puntos, delta reciente (+/-).
+- Sticky highlight para el usuario logueado si está fuera del viewport.
+- Fuentes de datos: resultados confirmados de partidos (`status = CONFIRMED`) y asistencia (no-shows).
+- Recalculo manual (server action) o automático tras guardar resultado; cron es “nice to have”.
+- Sin perfiles públicos aún; link del usuario propio va a `/me`.
+
+## Modelo de datos propuesto
+- Tabla `User` ya tiene `alias`, `displayName`, `level`.
+- Nueva tabla `RankingSnapshot` (para históricos y auditoría):
+  - `id`, `createdAt`, `season` (string, ej. `"global-2025-q1"`), `computedAt`.
+  - `entries`: modelado como tabla `RankingEntry`:
+    - `id`
+    - `userId` (FK User)
+    - `score` (float) — valor final para ordenar.
+    - `wins` (int), `losses` (int), `matchesPlayed` (int)
+    - `attendanceScore` (float 0–1) — penaliza no-shows.
+    - `streak` (int, positivos = victorias consecutivas, negativos = derrotas).
+    - `lastMatchAt` (DateTime)
+    - `position` (int)
+    - `positionChange` (int) — comparación contra snapshot previo (misma season).
+- Para MVP se puede persistir solo en `User` (`rankingScore`, `rankingPosition`, `rankingDelta`, `matchesPlayed`, `wins`, `losses`, `attendanceScore`, `lastMatchAt`) y luego migrar a snapshots.
+
+## Fórmula MVP (sujeta a ajuste)
+- Base: `score = 1000 + (wins * 15) + (losses * 0) + (streak * 5)`.
+- Bonus por sets ganados en victoria: +2 por set ganado; en derrota +1 por set ganado.
+- Penalización por no-show registrado: -25 por evento y reduce `attendanceScore`.
+- Atenuación temporal: resultados >60 días aplican un factor 0.5; >120 días factor 0.25.
+- `attendanceScore` = (partidos asistidos / partidos confirmados) limitado a [0,1]; se muestra como porcentaje.
+- Orden de desempate:
+  1) `score` (desc)
+  2) `attendanceScore` (desc)
+  3) `wins` (desc)
+  4) `lastMatchAt` (más reciente primero)
+
+## Backend / Server Actions
+- `recalculateRankingAction({ season?: string })`
+  - Requiere sesión admin (por ahora permitir cualquier usuario hasta tener roles).
+  - Lee partidos `status=CONFIRMED`, agrupa por jugador.
+  - Calcula métricas y score; guarda en `RankingEntry` y opcionalmente en `User` (campo cache).
+  - Revalida `/ranking` y `/me`.
+- `getRankingAction({ limit?: number, season?: string })`
+  - Devuelve array ordenado con: userId, displayNamePreferido, score, position, positionChange, level, attendanceScore, wins, losses, matchesPlayed, lastMatchAt.
+  - Incluye posición del usuario actual aunque esté fuera del top N (append “tu posición”).
+
+## UI / UX
+- **Vista Ranking** (`/ranking`):
+  1) Header: título “Ranking” + descripción corta “Posiciones actualizadas según resultados confirmados”.
+  2) Banner del usuario actual (card compacta) mostrando posición, puntos y delta; si no está en ranking, mostrar “Aún sin posición, jugá tu primer partido”.
+  3) Tabla / lista:
+     - Cada fila: `#pos`, avatar, nombre (alias preferido), nivel (badge), puntos grandes, delta (+/- con color), attendance (%), wins-loss.
+     - Filas táctiles, altura mínima 64px, con estados hover/focus/active.
+  4) CTA secundarios:
+     - Botón “Ver mis partidos” → `/match`
+     - Botón “Crear partido” → `/match/new`
+  5) Empty state: “Sin partidas confirmadas aún. Registrá resultados para entrar al ranking.”
+- **Vista Reputación** (sección separada o `tabs` dentro de `/ranking`):
+  1) Header corto: “Reputación” + copy: “Basada en asistencia y no-shows, no afecta tu ranking deportivo.”
+  2) Card del usuario actual: reputación (0–100), asistencias vs confirmaciones, no-shows y última incidencia.
+  3) Lista opcional: top usuarios por reputación (si se habilita) con avatar, alias, repScore%, matchesConfirmed, no-shows.
+  4) CTA secundario: “Ver mis partidos” → `/match` para mejorar asistencia.
+  5) Empty state: “Sin datos de asistencia aún.”
+- Mobile-first: usar layout en tarjetas apiladas o tabla responsiva con tipografía clara; en desktop se puede mostrar tabla densa.
+- Colores: mantener tema amarillo (primario) y uso de `text-muted-foreground` para subtítulos.
+- Accesibilidad: `aria-sort` en headers si se habilita orden; roles `row`/`cell`; texto alternativo en avatares (iniciales).
+
+## Validaciones y estados
+- Loading: skeleton de header + 5 filas.
+- Error: mensaje inline con retry (reinvocar `getRankingAction`).
+- Sin datos: empty state descrito arriba.
+- Inyección de preferencia de nombre: usar helper `getUserDisplayName(user)` (alias > displayName).
+
+## Integraciones transversales
+- `/me`: mostrar card “Tu ranking” con posición/puntos actuales y enlace a `/ranking`.
+- `MatchResultCompact` y demás tarjetas ya deberían honrar alias; mantener consistencia.
+- Revalidar `/ranking` y `/me` al confirmar resultados o actualizar alias (para reflejar display).
+
+## Métricas y trazabilidad
+- Loguear recalculos con duración y cantidad de usuarios procesados.
+- Guardar timestamp de último recalculo para mostrar “Actualizado hace X min”.
+- (Futuro) telemetry/analytics de clics en filas y CTAs.
+
+## Roadmap posterior
+- Filtros por club/zona.
+- Temporadas / ladders independientes.
+- Perfiles públicos de jugador desde fila del ranking.
+- Ajustar fórmula con ELO simplificado (K-factor) cuando haya suficientes datos.
+- Cron programado (Vercel cron) diario.

--- a/padelapp/src/app/(app)/ranking/page.tsx
+++ b/padelapp/src/app/(app)/ranking/page.tsx
@@ -1,0 +1,116 @@
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { mockRanking, mockCurrentUserRanking, mockReputation, mockReputationRanking } from "@/lib/mock-data";
+
+export default function RankingPage() {
+  return (
+    <div className="flex flex-col gap-6">
+      <header className="space-y-2">
+        <h1 className="text-2xl font-bold">Ranking & reputación</h1>
+        <p className="text-sm text-muted-foreground">
+          Puntos actualizados con decay mensual, categorías 1-8 y reputación por asistencia.
+        </p>
+      </header>
+
+      {mockCurrentUserRanking.hasPosition ? (
+        <Card className="bg-primary/5 border-primary/20">
+          <CardHeader className="flex items-center justify-between space-y-0">
+            <div>
+              <CardTitle className="text-base font-semibold">
+                Tu posición: #{mockCurrentUserRanking.position}
+              </CardTitle>
+              <CardDescription>
+                {mockCurrentUserRanking.points} pts · Nivel {mockCurrentUserRanking.level}
+              </CardDescription>
+            </div>
+            <Badge variant="default">{mockCurrentUserRanking.trend}</Badge>
+          </CardHeader>
+        </Card>
+      ) : (
+        <Card className="bg-muted/50">
+          <CardHeader>
+            <CardTitle className="text-base">Aún sin posición</CardTitle>
+            <CardDescription>
+              Jugá tu primer partido para entrar al ranking.
+            </CardDescription>
+          </CardHeader>
+        </Card>
+      )}
+
+      <Tabs defaultValue="individual" className="w-full">
+        <TabsList>
+          <TabsTrigger value="individual">Individual</TabsTrigger>
+          <TabsTrigger value="parejas">Parejas</TabsTrigger>
+          <TabsTrigger value="reputacion">Reputación</TabsTrigger>
+        </TabsList>
+        <TabsContent value="individual" className="space-y-3">
+          {mockRanking.map((player) => (
+            <Card key={player.position}>
+              <CardHeader className="flex items-center justify-between space-y-0">
+                <div>
+                  <CardTitle className="text-base font-semibold">
+                    {player.position}. {player.name}
+                  </CardTitle>
+                  <CardDescription>
+                    Nivel {player.level} · {player.points} pts
+                  </CardDescription>
+                </div>
+                <Badge variant="outline">{player.trend}</Badge>
+              </CardHeader>
+            </Card>
+          ))}
+        </TabsContent>
+        <TabsContent value="parejas" className="space-y-3">
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-base">Aún sin datos</CardTitle>
+              <CardDescription>
+                Cuando registres partidos con pareja fija verás su evolución aquí.
+              </CardDescription>
+            </CardHeader>
+          </Card>
+        </TabsContent>
+        <TabsContent value="reputacion" className="space-y-6">
+          <Card className="bg-primary/5 border-primary/20">
+            <CardHeader>
+              <CardTitle className="text-base">Tu Reputación</CardTitle>
+              <CardDescription>Basada en tu asistencia y cumplimiento.</CardDescription>
+            </CardHeader>
+            <CardContent className="flex items-center justify-between">
+              <div className="flex flex-col">
+                <span className="text-4xl font-black text-primary">{mockReputation.score}</span>
+                <span className="text-xs text-muted-foreground">reputation score</span>
+              </div>
+              <div className="text-right space-y-1">
+                <p className="text-sm font-medium">{mockReputation.attendanceRate} asistencia</p>
+                <p className="text-xs text-muted-foreground">{mockReputation.matchesConfirmed} partidos · {mockReputation.noShows} no-show</p>
+              </div>
+            </CardContent>
+          </Card>
+
+          <div className="space-y-3">
+            <h3 className="text-sm font-semibold text-muted-foreground uppercase px-1">Top Reputación</h3>
+            {mockReputationRanking.map((player) => (
+              <Card key={player.position}>
+                <CardHeader className="flex items-center justify-between space-y-0">
+                  <div>
+                    <CardTitle className="text-base font-semibold">
+                      {player.position}. {player.name}
+                    </CardTitle>
+                    <CardDescription>
+                      {player.matches} partidos confirmados
+                    </CardDescription>
+                  </div>
+                  <div className="text-right">
+                    <span className="text-lg font-bold text-primary">{player.score}%</span>
+                  </div>
+                </CardHeader>
+              </Card>
+            ))}
+          </div>
+        </TabsContent>
+      </Tabs>
+    </div>
+  );
+}

--- a/padelapp/src/lib/mock-data.ts
+++ b/padelapp/src/lib/mock-data.ts
@@ -1,0 +1,124 @@
+export const mockTurns = [
+  {
+    id: "abc123",
+    club: "Padel City",
+    level: 4,
+    date: "Sáb 18 Ene",
+    time: "18:00",
+    slots: { taken: 6, total: 8 },
+  },
+  {
+    id: "def456",
+    club: "La Nave",
+    level: 5,
+    date: "Dom 19 Ene",
+    time: "10:30",
+    slots: { taken: 3, total: 4 },
+  },
+];
+
+export const mockMatches = [
+  {
+    id: "match-01",
+    score: "6-4, 3-6, [10-7]",
+    winners: "Juan & Lucas",
+    losers: "María & Sofía",
+  },
+  {
+    id: "match-02",
+    score: "6-2, 6-3",
+    winners: "Paula & Nico",
+    losers: "Agus & Javi",
+  },
+];
+
+export const mockRanking = [
+  { position: 1, name: "Juan Pérez", level: 4, points: 1280, trend: "+2" },
+  { position: 2, name: "María López", level: 4, points: 1205, trend: "+1" },
+  { position: 3, name: "Lucas Fernández", level: 5, points: 1188, trend: "-1" },
+];
+
+export const mockReputation = {
+  score: 96,
+  attendanceRate: "98%",
+  matchesConfirmed: 42,
+  noShows: 1,
+  message: "¡Excelente! Ninguna ausencia en tus últimos 8 turnos.",
+};
+
+export const mockReputationRanking = [
+  { position: 1, name: "Juan Pérez", score: 100, matches: 56 },
+  { position: 2, name: "María López", score: 98, matches: 44 },
+  { position: 3, name: "Germán Aliprandi", score: 96, matches: 42 },
+  { position: 4, name: "Lucas Fernández", score: 92, matches: 38 },
+];
+
+export const mockCurrentUserRanking = {
+  position: 7,
+  name: "Germán Aliprandi",
+  level: 6,
+  points: 950,
+  trend: "+3",
+  hasPosition: true,
+};
+
+export const levelOptions = [
+  { value: "1", label: "Nivel 1 · Profesional" },
+  { value: "2", label: "Nivel 2 · Alta Competición" },
+  { value: "3", label: "Nivel 3 · Avanzado Plus" },
+  { value: "4", label: "Nivel 4 · Avanzado" },
+  { value: "5", label: "Nivel 5 · Intermedio Plus" },
+  { value: "6", label: "Nivel 6 · Intermedio" },
+  { value: "7", label: "Nivel 7 · Principiante Plus" },
+  { value: "8", label: "Nivel 8 · Principiante" },
+];
+
+export const mockFriends = [
+  { id: "user-juan", name: "Juan Pérez" },
+  { id: "user-maria", name: "María López" },
+  { id: "user-lucas", name: "Lucas Fernández" },
+  { id: "user-paula", name: "Paula Díaz" },
+  { id: "user-nico", name: "Nicolás Gómez" },
+  { id: "user-agus", name: "Agustina Romero" },
+  { id: "user-vale", name: "Valentina Ortiz" },
+  { id: "user-javi", name: "Javier Molina" },
+];
+
+export const mockPlayers = [
+  {
+    id: "player-1",
+    name: "Germán Aliprandi",
+    role: "Pareja A · Jugadora 1",
+    image: "https://lh3.googleusercontent.com/a/ACg8ocKQQbUOpdcWM2l5uGjq5gtLt1Lnmzyi-F4iWWWNzIj38QdLkrN9pA=s96-c",
+    isConfirmed: true,
+    ranking: 2,
+    category: 2,
+  },
+  {
+    id: "player-2",
+    name: "Diego Morales",
+    role: "Pareja A · Jugador 2",
+    image: "",
+    isConfirmed: false,
+    ranking: 5,
+    category: 4,
+  },
+  {
+    id: "player-3",
+    name: "María López",
+    role: "Pareja B · Jugadora 1",
+    image: "",
+    isConfirmed: true,
+    ranking: 3,
+    category: 3,
+  },
+  {
+    id: "player-4",
+    name: "Lucas Fernández",
+    role: "Pareja B · Jugador 2",
+    image: "",
+    isConfirmed: true,
+    ranking: 4,
+    category: 4,
+  },
+];


### PR DESCRIPTION
¡Hola! 🐜 Adrián reportándose. He completado una mejora incremental en la sección de **Ranking** de PadelApp.

### Cambios realizados:
1.  **Pestaña de Reputación**: Implementé la pestaña "Reputación" en \`/ranking\` que estaba marcada como pendiente en las especificaciones. Esta vista permite a los jugadores ver su puntaje de cumplimiento y quiénes son los usuarios más confiables de la comunidad.
2.  **Datos Mock Enriquecidos**: Amplié \`src/lib/mock-data.ts\` con métricas detalladas de asistencia (asistencia %, partidos confirmados, no-shows) y una lista de ranking por reputación.
3.  **Documentación**: Actualicé \`specs/ranking.md\` para reflejar que esta funcionalidad del MVP ya se encuentra parcialmente implementada.

### Nota Técnica:
Intenté realizar la verificación visual con el servidor de desarrollo, pero existe un error de tipos preexistente en \`src/auth.ts\` (mismatch de dependencias en \`PrismaAdapter\`) que impide el build en este entorno. Sin embargo, el código de la UI y los datos siguen estrictamente los patrones y componentes de shadcn/ui ya establecidos en el proyecto.

¡Un granito de arena más para que PadelApp sea la mejor herramienta para coordinar partidos! 🎾

---
*PR created automatically by Jules for task [2132707549262313176](https://jules.google.com/task/2132707549262313176) started by @galiprandi*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a "Ranking & Reputación" page displaying individual player rankings with positions, points, and trend indicators.
  * Included a tabbed interface with sections for Individual rankings, Pairs rankings, and Reputation statistics.
  * Reputation tab displays user's score, attendance rate, confirmed matches, and no-shows.
  * Current user's ranking position and level now visible with ability to view full leaderboard.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/galiprandi/me/pull/25?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->