### PR TITLE
🎨 Palette: Implement blog language switcher

### DIFF
--- a/src/components/Blog/LangSwitch.astro
+++ b/src/components/Blog/LangSwitch.astro
@@ -5,9 +5,19 @@ interface Props {
   otherLang: string | null;
 }
 
-const { slug, currentLang, otherLang } = Astro.props;
+const { slug, otherLang } = Astro.props;
 const base = "/me";
 ---
+
+{
+  otherLang && (
+    <div class="lang-switch">
+      <a href={`${base}/blog/${slug}/${otherLang}`}>
+        {otherLang === "en" ? "Read in English" : "Leer en Español"}
+      </a>
+    </div>
+  )
+}
 
 <style>
   .lang-switch {


### PR DESCRIPTION
💡 What: Implemented the missing logic in `LangSwitch.astro` to allow users to switch between English and Spanish versions of a blog post.

🎯 Why: This improves navigation for bilingual readers by providing a direct link to the translation of the current post, making the content more accessible and the interface more intuitive.

♿ Accessibility:
- Uses clear, localized labels for navigation links.
- Follows existing styling and layout patterns to maintain consistency.
- Correctly handles the presence/absence of other language versions.

Visual Evidence:
- Verified that "Leer en Español" appears on English posts.
- Verified that "Read in English" appears on Spanish posts.
- Confirmed that the links correctly navigate to the corresponding translations.

---
*PR created automatically by Jules for task [15257672042503545949](https://jules.google.com/task/15257672042503545949) started by @galiprandi*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized language switcher component to streamline language detection and link generation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/galiprandi/me/pull/27?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->