### PR TITLE
🎨 Palette: Improve accessibility of "More articles..." link

### DIFF
--- a/.axioma/palette.md
+++ b/.axioma/palette.md
@@ -5,3 +5,7 @@
 ## 2025-05-23 - [Robust Custom Media Player State]
 **Learning:** For custom media players (like the Podcast component), relying on click-toggle logic for UI state leads to desyncs (e.g., if playback fails or ends). Using native media events (`play`, `pause`, `ended`) ensures the UI accurately reflects the internal state.
 **Action:** Always synchronize custom media controls using native media events and ensure icons are marked `aria-hidden="true"` when the button has a descriptive `aria-label`.
+
+## 2025-05-24 - [Contextual Navigation Labels]
+**Learning:** Generic navigation links like "More articles..." lack sufficient context for screen reader users when encountered in isolation (e.g., via a links list).
+**Action:** Always provide descriptive `aria-label` attributes for generic links to ensure they are understandable in isolation, aligning with the pattern used in `PostCard.astro`.

--- a/src/components/Aside/PersonalBlog.astro
+++ b/src/components/Aside/PersonalBlog.astro
@@ -26,7 +26,12 @@ const base = "/me";
       ))
     }
     <li class="no-print">
-      <a href={`${base}/blog/en`}>More articles...</a>
+      <a
+        href={`${base}/blog/en`}
+        aria-label="More articles on my personal blog"
+      >
+        More articles...
+      </a>
     </li>
   </ul>
 </section>


### PR DESCRIPTION
💡 What: Improved the accessibility of the "More articles..." link in the Personal Blog sidebar section.
🎯 Why: Generic "More..." links are often confusing for screen reader users who might be navigating via a list of links. Adding a descriptive `aria-label` provides the necessary context.
♿ Accessibility: Added `aria-label="More articles on my personal blog"` to ensure the link's purpose is clear in isolation.

---
*PR created automatically by Jules for task [5850927506619416183](https://jules.google.com/task/5850927506619416183) started by @galiprandi*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility Improvements**
  * Navigation links now include descriptive aria-labels, ensuring they remain understandable when accessed in isolation (such as by screen readers or in links lists)

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/galiprandi/me/pull/28?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->