### PR TITLE
🎨 Palette: Add "Skip to content" link for keyboard accessibility

### DIFF
--- a/.axioma/palette.md
+++ b/.axioma/palette.md
@@ -9,3 +9,7 @@
 ## 2025-05-24 - [Contextual Navigation Labels]
 **Learning:** Generic navigation links like "More articles..." lack sufficient context for screen reader users when encountered in isolation (e.g., via a links list).
 **Action:** Always provide descriptive `aria-label` attributes for generic links to ensure they are understandable in isolation, aligning with the pattern used in `PostCard.astro`.
+
+## 2026-05-20 - [Accessible Skip to Content Link]
+**Learning:** For "Skip to content" links to work reliably across all browsers and screen readers, the target element (typically the `<main>` tag) must have `tabindex="-1"`. This ensures programmatic focus is correctly shifted, allowing the next keyboard navigation action to start from the correct location.
+**Action:** Always include `tabindex="-1"` on the destination ID when implementing skip-to-content functionality.

--- a/src/layouts/BlogLayout.astro
+++ b/src/layouts/BlogLayout.astro
@@ -91,6 +91,9 @@ const rssPath = lang === "en" ? "/blog/rss-en.xml" : "/blog/rss-es.xml";
     <script is:inline src={`${base}/googleTag.js`}></script>
   </head>
   <body class="blog">
+    <a href="#main-content" class="skip-link no-print">
+      {lang === "es" ? "Saltar al contenido" : "Skip to content"}
+    </a>
     <Header author="Germán A. Aliprandi" role="Personal Blog" />
     <nav class="blog-nav">
       <a href={`${base}/`}>
@@ -111,7 +114,7 @@ const rssPath = lang === "en" ? "/blog/rss-en.xml" : "/blog/rss-es.xml";
         )
       }
     </nav>
-    <main>
+    <main id="main-content" tabindex="-1">
       {
         updatedDate && (
           <small class="light">

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -74,6 +74,7 @@ const {
     <script is:inline src="/me/googleTag.js"></script>
   </head>
   <body class={multiPage ? "multi-page" : "one-page"}>
+    <a href="#main-content" class="skip-link no-print">Skip to content</a>
     <Header author={author} role={role} />
     <div class="columns">
       <Aside />

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -9,7 +9,7 @@ import Layout from "../layouts/Layout.astro";
   title="Germán Aliprandi"
   multiPage={false}
 >
-  <main>
+  <main id="main-content" tabindex="-1">
     <section class="section profile">
       <h3 class="upper">Summary (Profile)</h3>
       <p class="light small-in-print">

--- a/src/pages/portfolio/index.astro
+++ b/src/pages/portfolio/index.astro
@@ -7,7 +7,7 @@ import PortfolioList from "./components/PortfolioList.astro";
   title="💼 Germán A. Aliprandi"
   role="Projects & Open Source Contributions"
 >
-  <main>
+  <main id="main-content" tabindex="-1">
     <PortfolioList />
   </main>
 </Layout>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -73,6 +73,21 @@ p,
   color: var(--color-texts-light);
 }
 
+.skip-link {
+  position: absolute;
+  top: -100px;
+  left: 0;
+  background: var(--color-bg-pill);
+  color: var(--color-texts-light);
+  padding: 8px;
+  z-index: 100;
+  transition: top 0.3s;
+}
+
+.skip-link:focus {
+  top: 0;
+}
+
 /* Screens less than 900px */
 @media only screen and (max-width: 900px) {
   body {


### PR DESCRIPTION
💡 What: Added a "Skip to content" link to the resume and blog layouts.
🎯 Why: To improve keyboard accessibility by allowing users to bypass repetitive header and sidebar navigation.
♿ Accessibility:
- Link becomes visible only on focus using CSS transitions.
- Targets the `<main>` element with `tabindex="-1"` for reliable focus management.
- Fully localized in the blog section (Spanish/English).
- Hidden in print view using the `.no-print` utility.

---
*PR created automatically by Jules for task [230825946085608568](https://jules.google.com/task/230825946085608568) started by @galiprandi*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "skip to content" links across site layouts, enabling keyboard users to navigate directly to main content without scrolling through navigation menus
  * Enhanced focus management and targeting to improve keyboard navigation and screen reader accessibility throughout the site

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/galiprandi/me/pull/30?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->